### PR TITLE
Change UploadDate Property of a Book to a DateTime

### DIFF
--- a/NHentai.NET/Converters/DateTimeConverter.cs
+++ b/NHentai.NET/Converters/DateTimeConverter.cs
@@ -1,12 +1,25 @@
 ﻿using System;
-using System.Runtime.Serialization.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using NHentai.NET.Models.Books;
 
 namespace NHentai.NET.Converters
 {
     public class DateTimeConverter : JsonConverter<DateTime>
     {
+        /// <summary>
+        /// Converts the upload date property of a <see cref="Book"/> from a <see cref="JsonElement"/> to a
+        /// <see cref="DateTime"/> object during runtime.
+        /// </summary>
+        /// <remarks>
+        /// The default value for this <see cref="JsonElement"/> is a Unix epoch <see cref="int"/>.
+        /// </remarks>
+        /// <param name="reader">The Json reader.</param>
+        /// <param name="typeToConvert">The default Json type to be converted.</param>
+        /// <param name="options">Json serialization options.</param>
+        /// <returns>
+        /// A <see cref="Book"/> upload date parsed as <see cref="DateTime"/>.
+        /// </returns>
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var offset = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt32());

--- a/NHentai.NET/Converters/DateTimeConverter.cs
+++ b/NHentai.NET/Converters/DateTimeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.Serialization.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NHentai.NET.Converters
+{
+    public class DateTimeConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var offset = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt32());
+            return offset.UtcDateTime;
+        }
+
+        // Not Implemented
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NHentai.NET/Converters/FileTypeConverter.cs
+++ b/NHentai.NET/Converters/FileTypeConverter.cs
@@ -12,14 +12,17 @@ namespace NHentai.NET.Converters
     public class FileTypeConverter : JsonConverter<FileType>
     {
         /// <summary>
-        /// Converts the file extension of an <see cref="Image"/> from a <see cref="string"/> to a <see cref="FileType"/>
-        /// enum during runtime.
+        /// Converts the file type property of an <see cref="Image"/> from a <see cref="JsonElement"/> to a
+        /// <see cref="FileType"/> during runtime.
         /// </summary>
+        /// <remarks>
+        /// The default value for this <see cref="JsonElement"/> is a <see cref="string"/>.
+        /// </remarks>
         /// <param name="reader">The Json reader.</param>
         /// <param name="typeToConvert">The default Json type to be converted.</param>
         /// <param name="options">Json serialization options.</param>
         /// <returns>
-        /// An <see cref="Image"/> file extension as a <see cref="FileType"/>.
+        /// An <see cref="Image"/> file extension parsed as <see cref="FileType"/>.
         /// </returns>
         public override FileType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/NHentai.NET/Converters/IntegerConverter.cs
+++ b/NHentai.NET/Converters/IntegerConverter.cs
@@ -11,9 +11,8 @@ namespace NHentai.NET.Converters
     public class IntegerConverter : JsonConverter<int>
     {
         /// <summary>
-        /// Parses the Id property of <see cref="Book"/> from an <see cref="JsonElement"/> from it deserialized
-        /// state of an <see cref="int"/>.
-        /// <see cref="JsonElement"/> to an <see cref="int"/>.
+        /// Converts the Id property if a <see cref="Book"/> from a <see cref="JsonElement"/> to an
+        /// <see cref="int"/> during runtime.
         /// </summary>
         /// <param name="reader">The Json reader.</param>
         /// <param name="typeToConvert">The default Json type to be converted.</param>

--- a/NHentai.NET/Models/Books/Book.cs
+++ b/NHentai.NET/Models/Books/Book.cs
@@ -50,11 +50,9 @@ namespace NHentai.NET.Models.Books
         /// <summary>
         /// The book upload date.
         /// </summary>
-        /// <remarks>
-        /// This property is currently an <see cref="int"/> when parsed. DatTime parsing to be implemented later.
-        /// </remarks>
         [JsonPropertyName("upload_date")]
-        public int UploadDate { get; set; }
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime UploadDate { get; set; }
 
         /// <summary>
         /// The book tags.


### PR DESCRIPTION
The integer value for the `upload_date` Json element represents a Unix timestamp in seconds (don't know why I didn't realise this earlier). 
```json
"upload_date": 1476793729
```
I created a converter for this and changed the default type for the `UploadDate` property to `DateTime`. 